### PR TITLE
Remover a linha toolchain

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/gaitolini/EleicoesVirtual-back-end
 
 go 1.21
 
-toolchain go1.22.3
+// toolchain go1.22.3
 
 require (
 	cloud.google.com/go/firestore v1.17.0


### PR DESCRIPTION
O problema está relacionado à diretiva toolchain go1.22.3 no seu arquivo go.mod. Como o Docker está utilizando uma versão diferente do Go, essa diretiva não é reconhecida corretamente.

Para garantir compatibilidade com o ambiente Docker